### PR TITLE
[feat] 로딩 화면 수정 및 옷 조회 데이터 연결 수정

### DIFF
--- a/app/src/main/java/ddwu/com/mobile/wearly_frontend/upload/ui/activity/ClothingDetailActivity.kt
+++ b/app/src/main/java/ddwu/com/mobile/wearly_frontend/upload/ui/activity/ClothingDetailActivity.kt
@@ -2,7 +2,11 @@ package ddwu.com.mobile.wearly_frontend.upload.ui.activity
 
 import android.os.Bundle
 import android.util.Log
+import android.view.View
+import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
@@ -11,11 +15,13 @@ import ddwu.com.mobile.wearly_frontend.R
 import ddwu.com.mobile.wearly_frontend.databinding.ActivityClothingDetailBinding
 import ddwu.com.mobile.wearly_frontend.upload.data.model.closet.Category
 import ddwu.com.mobile.wearly_frontend.upload.data.model.closet.ClosetDto
+import ddwu.com.mobile.wearly_frontend.upload.data.model.closet.ClothesDetailDto
 import ddwu.com.mobile.wearly_frontend.upload.data.model.closet.ClothingUpdateRequestDto
 import ddwu.com.mobile.wearly_frontend.upload.data.remote.ApiClient
 import ddwu.com.mobile.wearly_frontend.upload.data.repository.ClosetRepository
 import ddwu.com.mobile.wearly_frontend.upload.data.repository.OutfitRepository
 import kotlinx.coroutines.launch
+
 
 class ClothingDetailActivity : AppCompatActivity() {
     private lateinit var binding: ActivityClothingDetailBinding
@@ -27,6 +33,9 @@ class ClothingDetailActivity : AppCompatActivity() {
     private val outfitRepository by lazy {
         OutfitRepository(ApiClient.closetApi())
     }
+
+    // 수정 후
+    private var changed = false
 
     private var clothingId: Long = -1L
     private var currentSectionId: Long = -1L
@@ -46,9 +55,9 @@ class ClothingDetailActivity : AppCompatActivity() {
 
     // 수정 API는 바뀐 필드만 호출
     private var isBinding = true
-    private var lastClosetId: Int? = null
+    private var lastClosetId: Long? = null
     private var lastSectionId: Int? = null
-    private var lastCategoryId: Int? = null
+    private var lastCategoryId: Long? = null
 
     private var updateJob: kotlinx.coroutines.Job? = null
 
@@ -66,12 +75,15 @@ class ClothingDetailActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayShowTitleEnabled(false)
 
-        toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setNavigationOnClickListener {
+            if (changed) setResult(RESULT_OK)
+            finish()
+        }
 
         binding.spType.setOnItemClickListener { _, _, pos, _ ->
             if (isBinding) return@setOnItemClickListener
             val newId = categories[pos].category_id
-            if (newId == lastCategoryId) return@setOnItemClickListener
+            if (newId.toLong() == lastCategoryId) return@setOnItemClickListener
 
             lifecycleScope.launch {
                 runCatching {
@@ -79,11 +91,36 @@ class ClothingDetailActivity : AppCompatActivity() {
                         clothingId,
                         ClothingUpdateRequestDto(categoryId = newId)
                     )
-                    lastCategoryId = newId
+                    lastCategoryId = newId?.toLong()
+                    changed = true
                     setResult(RESULT_OK)
                 }
             }
         }
+
+        binding.spSection.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
+                if (isBinding) return
+
+                val newId = sections[pos].sectionId
+                if (newId == lastSectionId) return
+
+                lifecycleScope.launch {
+                    runCatching {
+                        closetRepository.updateClothing(
+                            clothingId,
+                            ClothingUpdateRequestDto(sectionId = newId)
+                        )
+                        lastSectionId = newId
+                        changed = true
+                        setResult(RESULT_OK)
+                    }
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+
 
         binding.spSection.setOnItemClickListener { _, _, pos, _ ->
             if (isBinding) return@setOnItemClickListener
@@ -97,27 +134,12 @@ class ClothingDetailActivity : AppCompatActivity() {
                         ClothingUpdateRequestDto(sectionId = newId)
                     )
                     lastSectionId = newId
+                    changed = true
                     setResult(RESULT_OK)
                 }
             }
         }
 
-        binding.spCloset.setOnItemClickListener { _, _, pos, _ ->
-            if (isBinding) return@setOnItemClickListener
-            val newId = closets[pos].closet_id
-            if (newId == lastClosetId) return@setOnItemClickListener
-
-            lifecycleScope.launch {
-                runCatching {
-                    closetRepository.updateClothing(
-                        clothingId,
-                        ClothingUpdateRequestDto(closetId = newId)
-                    )
-                    lastClosetId = newId
-                    setResult(RESULT_OK)
-                }
-            }
-        }
 
         if (clothingId == -1L) {
             finish()
@@ -157,27 +179,63 @@ class ClothingDetailActivity : AppCompatActivity() {
                 binding.spSection.setAdapter(spinnerAdapter(sectionNames))
                 Log.d("DETAIL", "spSection adapter set: $sectionNames")
 
-                // 마지막에만
+
+                isBinding = true
+
+                val closetName = intent.getStringExtra("closet")
+                val sectionName = intent.getStringExtra("section")
+
+                Log.d("DETAIL", "intent closet='$closetName', section='$sectionName'")
+
+                /*detail.section_id?.let { secId ->
+                    val secPos = sections.indexOfFirst { it.sectionId == secId }
+                    if (secPos >= 0) binding.spSection.setText(sections[secPos].name, false)
+                } ?: run {
+                    if (!sectionName.isNullOrBlank()) binding.spSection.setText(sectionName, false)
+                }
+
+                 */
+                if (!sectionName.isNullOrBlank()) {
+                    binding.spSection.setText(sectionName, false)
+                }
+
+                lastCategoryId = detail.category_id?.toLong()
+                val catPos = categories.indexOfFirst { it.category_id?.toLong() == lastCategoryId }
+                if (catPos >= 0) binding.spType.setText(categories[catPos].name, false)
+
+                if (!closetName.isNullOrBlank()) {
+                    binding.spCloset.setText(closetName, false)
+                }
+
                 isBinding = false
-                Log.d("DETAIL", "binding done")
+
+
 
             } catch (e: Exception) {
                 Log.e("DETAIL", "load failed", e)
             }
         }
 
-
         // 옷 삭제
         binding.btnDelete.setOnClickListener {
-            lifecycleScope.launch {
-                runCatching {
-                    closetRepository.deleteClothing(clothingId)
-                    setResult(RESULT_OK)
-                    finish()
-                }.onFailure {
-                    // Toast.makeText(this@ClothingDetailActivity, "삭제 실패", Toast.LENGTH_SHORT).show()
+
+            AlertDialog.Builder(this)
+                .setTitle("옷 삭제")
+                .setMessage("정말 이 옷을 삭제하시겠습니까?")
+                .setPositiveButton("삭제") { _, _ ->
+                    lifecycleScope.launch {
+                        runCatching {
+                            closetRepository.deleteClothing(clothingId)
+                            changed = true
+                            setResult(RESULT_OK)
+                            finish()
+                        }.onFailure {
+                            Toast.makeText(this@ClothingDetailActivity, "삭제 실패", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 }
-            }
+                .setNegativeButton("취소", null)
+                .show()
         }
 
 

--- a/app/src/main/java/ddwu/com/mobile/wearly_frontend/upload/ui/activity/UploadActivity.kt
+++ b/app/src/main/java/ddwu/com/mobile/wearly_frontend/upload/ui/activity/UploadActivity.kt
@@ -45,11 +45,6 @@ class UploadActivity : AppCompatActivity() {
         ClosetRepository(ApiClient.closetApi())
     }
 
-    private val uploadRepository by lazy {
-        UploadRepository(ApiClient.uploadApi())
-    }
-
-
     // 카메라 실행용
     private val cameraLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -103,6 +98,7 @@ class UploadActivity : AppCompatActivity() {
             if (isGranted) openCameraInternal()
         }
 
+
     private val detailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
@@ -123,7 +119,8 @@ class UploadActivity : AppCompatActivity() {
 
         // 섹션 전달 받기
         val name = intent.getStringExtra("containerName")
-        currentSectionId = intent.getIntExtra("sectionId", -1)
+        //currentSectionId = intent.getIntExtra("sectionId", -1)
+        currentSectionId = 50
         val closet = intent.getStringExtra("closet")
         if (currentSectionId == -1) { finish(); return }
 
@@ -135,8 +132,7 @@ class UploadActivity : AppCompatActivity() {
             onAddClick = { openCamera() },
             onImageClick = { imageItem ->
                 val clothingId = imageItem.id ?: return@ClothingAdapter
-                Log.d("CLICK", "clicked id=${imageItem.id}, url=${imageItem.imageUrl}")
-                startActivity(
+                detailLauncher.launch(
                     Intent(this, ClothingDetailActivity::class.java).apply {
                         putExtra("section", name)
                         putExtra("closet", closet)
@@ -144,7 +140,6 @@ class UploadActivity : AppCompatActivity() {
                         putExtra("imageUrl", imageItem.imageUrl)
                     }
                 )
-
             }
         )
 

--- a/app/src/main/res/layout/activity_loading_upload.xml
+++ b/app/src/main/res/layout/activity_loading_upload.xml
@@ -5,7 +5,9 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white">
+    android:background="@android:color/white"
+    android:paddingHorizontal="4dp"
+    android:paddingVertical="8dp">
 
     <!-- 가운데 큰 원 아이콘 -->
     <ImageView
@@ -49,9 +51,12 @@
     <!-- 단계 표시 -->
     <LinearLayout
         android:id="@+id/stepRow"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="46dp"
         android:layout_marginTop="24dp"
+        android:layout_marginEnd="46dp"
+        android:baselineAligned="false"
         android:gravity="center"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
@@ -60,26 +65,24 @@
 
         <include
             android:id="@+id/step1"
-            layout="@layout/step_item"/>
-
-        <Space
-            android:layout_width="44dp"
-            android:layout_height="1dp"/>
+            layout="@layout/step_item"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
 
         <include
             android:id="@+id/step2"
-            layout="@layout/step_item"/>
-
-        <Space
-            android:layout_width="44dp"
-            android:layout_height="1dp"/>
+            layout="@layout/step_item"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
 
         <include
             android:id="@+id/step3"
-            layout="@layout/step_item"/>
-
+            layout="@layout/step_item"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
     </LinearLayout>
-
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/step_item.xml
+++ b/app/src/main/res/layout/step_item.xml
@@ -4,29 +4,39 @@
     android:id="@+id/stepRoot"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_margin="0dp"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     android:gravity="center"
     android:orientation="vertical"
-    android:padding="10dp">
+    android:paddingHorizontal="0dp"
+    android:paddingVertical="6dp">
 
-    <!-- 숫자 / 체크 원 -->
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/stepCircle"
-        android:layout_width="44dp"
-        android:layout_height="44dp"
-        app:cardCornerRadius="22dp"
-        app:cardElevation="4dp">
+    <FrameLayout
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:layout_gravity="center"
+        android:clipChildren="false"
+        android:clipToPadding="false">
 
-        <TextView
-            android:id="@+id/tvMark"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:text="1"
-            android:textSize="14sp"
-            android:textStyle="bold" />
-    </com.google.android.material.card.MaterialCardView>
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/stepCircle"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_gravity="center"
+            app:cardCornerRadius="22dp"
+            app:cardElevation="4dp">
 
+            <TextView
+                android:id="@+id/tvMark"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:text="1"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+        </com.google.android.material.card.MaterialCardView>
+
+    </FrameLayout>
     <!-- 라벨 (원 아래) -->
     <TextView
         android:id="@+id/tvLabel"


### PR DESCRIPTION
💡 기능 설명
로딩 화면을 요구사항에 맞춰 수정하였습니다.
또, 옷 조회 시 현재 위치가 나타나지 않는 현상을 수정하고
옷 삭제 시 리사이클러뷰에 그대로 남아있던 현상을 수정하였습니다.

 ⛳ 작업한 브랜치
feature/closet-fetch

 🛠 작업 상세 내용
- [x]  로딩 화면 수정(1, 2, 3 스텝 동그라미 잘림 이슈) 
- [x]  옷 조회 화면 수정(처음에 현재 위치가 표시되지 않는 이슈)
- [x]  업로드, 삭제 API 확인

 📸 스크린샷

 💬 전달 사항
옷장 연결 부분 수정을 위해 기니 코드를 수정하도록 하겠습니다.